### PR TITLE
close unnecessary $HOME hole in sandbox

### DIFF
--- a/com.github.hugolabe.Wike.json
+++ b/com.github.hugolabe.Wike.json
@@ -10,8 +10,7 @@
     "--socket=fallback-x11",
     "--socket=wayland",
     "--socket=pulseaudio",
-    "--device=dri",
-    "--filesystem=home"
+    "--device=dri"
   ],
   "modules" : [
     "python3-dbus-python.json",


### PR DESCRIPTION
Wike does not need access to $HOME as it merely opens files $XDG_DATA_HOME that inside the flatpak sandbox is assured to be set to an accessible path.

see upstream PR hugolabe/Wike#129