### PR TITLE
Bump Gnome runtime to 48

### DIFF
--- a/com.github.hugolabe.Wike.json
+++ b/com.github.hugolabe.Wike.json
@@ -1,7 +1,7 @@
 {
   "app-id" : "com.github.hugolabe.Wike",
   "runtime" : "org.gnome.Platform",
-  "runtime-version" : "47",
+  "runtime-version" : "48",
   "sdk" : "org.gnome.Sdk",
   "command" : "wike",
   "finish-args" : [


### PR DESCRIPTION
Bump Gnome runtime according to https://github.com/hugolabe/Wike/commit/8956873db2329ff30808fb458e6551b4d5238d7b .